### PR TITLE
Fixed certificate chooser display in Firefox 53

### DIFF
--- a/data/certChooser.js
+++ b/data/certChooser.js
@@ -15,7 +15,10 @@ var certNicknames = document.getElementById("certNicknames");
 for (var key in data.certs) {
   var option = document.createElement("option");
   option.setAttribute("value", key);
-  option.textContent = data.certs[key].nickname;
+  if(data.certs[key].nickname)
+    option.textContent = data.certs[key].nickname;
+  else
+    option.textContent = data.certs[key].token + ":" + data.certs[key].serialNumber;
   certNicknames.appendChild(option);
 }
 


### PR DESCRIPTION
Property nickname of nsIX509Cert is removed in Firefox 53 - you can check [Mozilla bug 857627](https://bugzilla.mozilla.org/show_bug.cgi?id=857627) for details. This change will provide interface similar to UI in current version of Firefox.