### PR TITLE
Not working on Macos Catalina (new release required)

### DIFF
--- a/installer/macos/build-installer
+++ b/installer/macos/build-installer
@@ -18,7 +18,7 @@ mkdir signtextjs_plus.app
 cd signtextjs_plus.app
 install "$TOPDIR"/src/macos/signtextjs_plus .
 install -m 644 \
-	/usr/local/opt/jsoncpp/lib/libjsoncpp.19.dylib \
+	/usr/local/opt/jsoncpp/lib/libjsoncpp.21.dylib \
 	/usr/local/opt/nspr/lib/libnspr4.dylib \
 	/usr/local/opt/nspr/lib/libplc4.dylib \
 	/usr/local/opt/nspr/lib/libplds4.dylib \

--- a/src/macos/Makefile
+++ b/src/macos/Makefile
@@ -1,5 +1,5 @@
 signtextjs_plus: ../signtextjs_plus.cpp ../config.h
-	g++ -Wall -O2 -g -I/usr/include/jsoncpp -I/usr/local/opt/nspr/include \
+	g++ -Wall -O2 -g -std=c++0x -I/usr/include/jsoncpp -I/usr/local/opt/nspr/include \
 		-I/usr/local/opt/nspr/include/nspr \
 		-I/usr/local/opt/nss/include -L/usr/local/opt/nspr/lib \
 		-L/usr/local/opt/nss/lib -o $@ $< -ljsoncpp -lnspr4 -lnss3 \

--- a/test/macos/Makefile
+++ b/test/macos/Makefile
@@ -1,5 +1,5 @@
 test: ../test.cpp ../config.h
-	g++ -Wall -O2 -g -I/usr/include/jsoncpp -o $@ $< -ljsoncpp
+	g++ -Wall -O2 -g -std=c++0x -I/usr/include/jsoncpp -o $@ $< -ljsoncpp
 
 ../config.h: ../../src/config.h
 	cp -a $< $@

--- a/travis/osx..install
+++ b/travis/osx..install
@@ -4,4 +4,14 @@ set -e
 brew install \
 	jsoncpp \
 	nss
+
+JSONCPPDYLIB=/usr/local/opt/jsoncpp/lib/libjsoncpp.21.dylib
+if [ ! -f "$JSONCPPDYLIB" ]
+then
+    echo "$JSONCPPDYLIB does not exist"
+	echo "Look for the correct dylib name with 'ls /usr/local/opt/jsoncpp/lib/libjsoncpp.*.dylib'"
+	echo "Then modify the installer/macos/build-installer with the correct name"
+	exit
+fi
+
 sudo npm install -g appdmg


### PR DESCRIPTION
Thanks for maintaining this extension, without it it would not be possible to use Bulgaria's eSignatures in a lot of web sites.

After trying to install it on macos Catalina I encountered the `Library not loaded: /usr/local/opt/jsoncpp/lib/libjsoncpp.19.dylib` error. Unfortunately installing the jsoncpp and nss libraries did not fix it as the installed dylib's name is now 'libjsoncpp.21.dylib'.

I see that you have added changes to make the libs as part of the application but it has not been released. Please make a new release to save a lot of people the pain to compile it themselves.

I managed to build the DMG myself and this worked, but I encountered a few hurdles.

1. The g++ command required the  `-std=c++0x` flag. I don't know why, I havent done c++ programing in 15 years.
2. I added a check for the correct name of the dylib.

I created the pull request just to show you the changes required. Discard it if you wish so.

What I ask for is a new release with the embedded libs.

PS: for any bulgarians having a hard time with BTrust's eSignatures check this gist https://gist.github.com/angelyordanov/c89409dc565e3d92c1fc361222dff465